### PR TITLE
Increase size of 'go-to-guide' link

### DIFF
--- a/_views/index.pug
+++ b/_views/index.pug
@@ -13,7 +13,7 @@ block content
   section.container.my-5.pt-5
     .row.my-5
       .col-12.col-md.text-center
-        a(href='https://docs.solarwallet.io') Go to guide &rarr;
+        a.h2(href='https://docs.solarwallet.io') Go to guide &rarr;
   section.container.my-5
     .row.my-5.pt-5
       .col-12.col-md


### PR DESCRIPTION
I think it is too easy to miss. At first, I did not see it although I knew it had to be somewhere.